### PR TITLE
Pin Ruby 3.0.2 for GitHub workflow

### DIFF
--- a/.github/workflows/post-report-data.yml
+++ b/.github/workflows/post-report-data.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2
       - run: bundle config set without "development test"
       - run: bundle install
       - run: bin/post-data.sh


### PR DESCRIPTION
This PR pins Ruby version `3.0.2` in the GitHub workflow (updating it to use [ruby/setup-ruby](https://github.com/ruby/setup-ruby) in the process) to [fix failed runs](https://github.com/ministryofjustice/github-repository-standards/actions/runs/1623359877) due to Ruby version mismatches.